### PR TITLE
Bugfix/condition for precompilestep

### DIFF
--- a/src/FEntwumS.SVNRExtension/AsmToVhdlPreCompileStep.cs
+++ b/src/FEntwumS.SVNRExtension/AsmToVhdlPreCompileStep.cs
@@ -18,6 +18,10 @@ public class AsmToVhdlPreCompileStep(AsmConverterService converterService, ILogg
         
         try
         {
+            if (!SvnrSettingsHelper.IsSvnrToolchainActive(project))
+            {
+                return true;
+            }
             var asmPath = SvnrSettingsHelper.GetAsmFile(project);
             if (asmPath.Equals("none"))
             {

--- a/src/FEntwumS.SVNRExtension/Services/SvnrToolchainService.cs
+++ b/src/FEntwumS.SVNRExtension/Services/SvnrToolchainService.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.Extensions.Logging;
 using OneWare.Essentials.Services;
 using OneWare.GhdlExtension.Services;
+using OneWare.OssCadSuiteIntegration.Yosys;
 using OneWare.UniversalFpgaProjectSystem.Models;
 
 namespace FEntwumS.SVNRExtension.Services;
 
-public class SvnrToolchainService(GhdlToolchainService ghdlToolchain, AsmToVhdlPreCompileStep asmPreCompiler)
+public class SvnrToolchainService(YosysService yosysService, AsmToVhdlPreCompileStep asmPreCompiler)
 {
     
     public async Task<bool> CompileAsync(UniversalFpgaProjectRoot project, FpgaModel fpga)
@@ -23,7 +24,7 @@ public class SvnrToolchainService(GhdlToolchainService ghdlToolchain, AsmToVhdlP
 
         try
         {
-            success = await ghdlToolchain.CompileAsync(project, fpga);
+            success = await yosysService.CompileAsync(project, fpga);
             return success;
         }
         catch (Exception e)
@@ -35,12 +36,12 @@ public class SvnrToolchainService(GhdlToolchainService ghdlToolchain, AsmToVhdlP
 
     public async Task<bool> FitAsync(UniversalFpgaProjectRoot project, FpgaModel fpga)
     {
-        return await ghdlToolchain.FitAsync(project, fpga);
+        return await yosysService.FitAsync(project, fpga);
     }
 
     public async Task<bool> AssembleAsync(UniversalFpgaProjectRoot project, FpgaModel fpga)
     {
-        return await ghdlToolchain.AssembleAsync(project, fpga);
+        return await yosysService.AssembleAsync(project, fpga);
     }
 
 

--- a/src/FEntwumS.SVNRExtension/Tools/SvnrSettingsHelper.cs
+++ b/src/FEntwumS.SVNRExtension/Tools/SvnrSettingsHelper.cs
@@ -31,6 +31,11 @@ public class SvnrSettingsHelper
     {
         return project.Properties.GetString("SVNR/AsmFile") ?? "none";
     }
+
+    public static bool IsSvnrToolchainActive(UniversalFpgaProjectRoot project)
+    {
+        return project.Properties.GetString("Toolchain") == "svnr";
+    }
     
     public static void UpdateProjectProperties(UniversalFpgaProjectRoot project, string? asmFile)
     {


### PR DESCRIPTION
The Precompilestep now only runs if the SVNR-Toolchain is active.
Additionally switched the used Toolchain from GHDL-Yosys to Yosys, since it now provides all the needed functionality.